### PR TITLE
[Chore/#13] - yml openApi setting

### DIFF
--- a/DongneRing/src/main/resources/application.yml
+++ b/DongneRing/src/main/resources/application.yml
@@ -42,6 +42,10 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
 
+serviceKey:
+  openApi:
+    news-secret: ${serviceKey.openApi.news-secret}
+    art-secret: ${serviceKey.openApi.art-secret}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
## Description

Chore/#13: yml openApi setting

언제 날라간지도 모르는 openApi 키 세팅 다시 넣어놓겠습니다 ..
없어도 돌아가기는 하나 초기에 배포 서버에 데베 세팅이 안 되길래 이것저것 해보다가 로컬로 돌려서 데베 세팅 완료하였습니다. 혹시 또 안 될까 싶어 다시 넣어놓습니다 .. 